### PR TITLE
Adjustment of stopping criteria

### DIFF
--- a/src/ODETools/ODESolutions.jl
+++ b/src/ODETools/ODESolutions.jl
@@ -57,7 +57,7 @@ function Base.iterate(sol::GenericODESolution, state)
 
   uf,u0,t0,cache = state
 
-  if t0 >= sol.tF
+  if t0 >= sol.tF - 100*eps()
     return nothing
   end
 

--- a/src/ODETools/ODESolutions.jl
+++ b/src/ODETools/ODESolutions.jl
@@ -57,7 +57,7 @@ function Base.iterate(sol::GenericODESolution, state)
 
   uf,u0,t0,cache = state
 
-  if t0 >= sol.tF - 100*eps()
+  if t0 >= sol.tF - ϵ
     return nothing
   end
 

--- a/src/ODETools/ODETools.jl
+++ b/src/ODETools/ODETools.jl
@@ -4,6 +4,7 @@ using Test
 
 using ForwardDiff
 
+const ϵ = 100*eps()
 export ∂t
 export time_derivative
 


### PR DESCRIPTION
Change of stopping criteria to t < tF - epsilon
This is to avoid an extra step which may be taken due to a rounding error