### PR TITLE
add method to TransientFEOperators

### DIFF
--- a/src/TransientFETools/TransientFEOperators.jl
+++ b/src/TransientFETools/TransientFEOperators.jl
@@ -116,6 +116,21 @@ function TransientFEOperator(trial,test,terms...)
   TransientFEOperatorFromTerms{Nonlinear}(trial,∂t(trial),test,assem_t,terms...)
 end
 
+function TransientConstantFEOperator(mat::Type,trial,test,terms...)
+  assem_t = SparseMatrixAssembler(mat,test,evaluate(trial,nothing))
+  TransientFEOperatorFromTerms{Constant}(trial,∂t(trial),test,assem_t,terms...)
+end
+
+function TransientAffineFEOperator(mat::Type,trial,test,terms...)
+  assem_t = SparseMatrixAssembler(mat,test,evaluate(trial,nothing))
+  TransientFEOperatorFromTerms{Affine}(trial,∂t(trial),test,assem_t,terms...)
+end
+
+function TransientFEOperator(mat::Type,trial,test,terms...)
+  assem_t = SparseMatrixAssembler(mat,test,evaluate(trial,nothing))
+  TransientFEOperatorFromTerms{Nonlinear}(trial,∂t(trial),test,assem_t,terms...)
+end
+
 get_assembler(feop::TransientFEOperatorFromTerms) = feop.assem_t
 
 get_test(op::TransientFEOperatorFromTerms) = op.test


### PR DESCRIPTION
This is to add the option to construct a TransientFEOperator from a specified matrix format