### PR TITLE
Added TransientTrialFreeFESpace and corresponding tests

### DIFF
--- a/test/TransientFEsTests/TransientFETests.jl
+++ b/test/TransientFEsTests/TransientFETests.jl
@@ -37,6 +37,9 @@ U = TransientTrialFESpace(V0,u)
 U0 = TrialFESpace(V0,u(0.0))
 @test test_transient_trial_fe_space(U)
 
+U_noBC = TransientTrialFESpace(V0)
+@test test_transient_trial_fe_space(U_noBC)
+
 U0 = U(1.0)
 ud0 = copy(get_dirichlet_values(U0))
 _ud0 = get_dirichlet_values(U0)


### PR DESCRIPTION
I defined `TransientTrialFESpace` as an abstract type with the subtypes `TransientTrialDirichletFESpace` and `TransientTrialFreeFESpace`. The former corresponds to the original `TransientTrialFESpace` and the later implements the functions that were assuming the presence of Dirichlet data. 

These changes are required to define transient FE spaces without strong Dirichlet data, which is relevant when only imposing weak boundary conditions.

Closes #41 