### PR TITLE
Transient multi field cell field

### DIFF
--- a/src/TransientFETools/TransientCellField.jl
+++ b/src/TransientFETools/TransientCellField.jl
@@ -29,6 +29,27 @@ gradient(f::TransientSingleFieldCellField) = gradient(f.cellfield)
 ∇∇(f::TransientSingleFieldCellField) = ∇∇(f.cellfield)
 change_domain(f::TransientSingleFieldCellField,trian::Triangulation,target_domain::DomainStyle) = change_domain(f.cellfield,trian,target_domain)
 
+# Skeleton related Operations
+function Base.getproperty(f::TransientSingleFieldCellField, sym::Symbol)
+  if sym in (:⁺,:plus,:⁻, :minus)
+    derivatives = ()
+    if sym in (:⁺,:plus)
+      cellfield = CellFieldAt{:plus}(f.cellfield)
+      for iderivative in f.derivatives
+        derivatives = (derivatives...,CellFieldAt{:plus}(iderivative))
+      end
+    elseif sym in (:⁻, :minus)
+      cellfield = CellFieldAt{:minus}(f.cellfield)
+      for iderivative in f.derivatives
+        derivatives = (derivatives...,CellFieldAt{:plus}(iderivative))
+      end
+    end
+    return TransientSingleFieldCellField(cellfield,derivatives)
+  else
+    return getfield(f, sym)
+  end
+end
+
 # Transient FEBasis
 struct TransientFEBasis{A} <: FEBasis
   febasis::A

--- a/src/TransientFETools/TransientCellField.jl
+++ b/src/TransientFETools/TransientCellField.jl
@@ -1,49 +1,33 @@
 # Transient CellField
-struct TransientCellField{A} <: CellField
+abstract type TransientCellField <: CellField end
+
+get_data(f::TransientCellField) = @abstractmethod
+get_triangulation(f::TransientCellField) = @abstractmethod
+DomainStyle(::Type{TransientCellField}) =  @abstractmethod
+gradient(f::TransientCellField) =  @abstractmethod
+∇∇(f::TransientCellField) =  @abstractmethod
+function change_domain(f::TransientCellField,trian::Triangulation,target_domain::DomainStyle)
+  @abstractmethod
+end
+
+struct TransientSingleFieldCellField{A} <: TransientCellField
   cellfield::A
   derivatives::Tuple#{Vararg{A,B} where B}
 end
 
-# CellField methods
-get_data(f::TransientCellField) = get_data(f.cellfield)
-get_triangulation(f::TransientCellField) = get_triangulation(f.cellfield)
-DomainStyle(::Type{<:TransientCellField{A}}) where A = DomainStyle(A)
-gradient(f::TransientCellField) = gradient(f.cellfield)
-∇∇(f::TransientCellField) = ∇∇(f.cellfield)
-change_domain(f::TransientCellField,trian::Triangulation,target_domain::DomainStyle) = change_domain(f.cellfield,trian,target_domain)
+SingleFieldTypes = Union{GenericCellField,SingleFieldFEFunction}
 
-# MultiFieldCellField methods
-num_fields(f::TransientCellField{A}) where A = num_fields(f.cellfield)
-function Base.getindex(f::TransientCellField{A},i::Integer) where A 
-  singleCellfield = getindex(f.cellfield,i)
-  singleDerivatives = ()
-  for i_derivatives in f.derivatives
-    singleDerivatives = (singleDerivatives...,getindex(i_derivatives,i))
-  end
-  # singleDerivatives = (getindex(i_derivatives,i) for i_derivatives in f.derivatives)
-  TransientCellField(singleCellfield,singleDerivatives)
+function TransientCellField(single_field::SingleFieldTypes,derivatives::Tuple)
+  TransientSingleFieldCellField(single_field,derivatives)
 end
-function Base.iterate(f::TransientCellField{A}) where A
-  cellField, state1 = iterate(f.cellfield)
-  derivatives = ()
-  state2 = []
-  for i_derivatives in f.derivatives
-    single_derivative, single_state = iterate(i_derivatives)
-    derivatives = (derivatives...,single_derivative)
-    push!(state2,single_state)
-  end
-  TransientCellField(cellField,derivatives),(state1,state2)
-end
-function Base.iterate(f::TransientCellField{A},state) where A
-  state1, state2 = state
-  cellField, state1 = iterate(f.cellfield,state[1])
-  derivatives = ()
-  for (i,i_derivatives) in enumerate(f.derivatives)
-    single_derivative, state2[i] = iterate(i_derivatives)
-    derivatives = (derivatives...,single_derivative)
-  end
-  TransientCellField(cellField,derivatives),(state1, state2)
-end
+
+# CellField methods
+get_data(f::TransientSingleFieldCellField) = get_data(f.cellfield)
+get_triangulation(f::TransientSingleFieldCellField) = get_triangulation(f.cellfield)
+DomainStyle(::Type{<:TransientSingleFieldCellField{A}}) where A = DomainStyle(A)
+gradient(f::TransientSingleFieldCellField) = gradient(f.cellfield)
+∇∇(f::TransientSingleFieldCellField) = ∇∇(f.cellfield)
+change_domain(f::TransientSingleFieldCellField,trian::Triangulation,target_domain::DomainStyle) = change_domain(f.cellfield,trian,target_domain)
 
 # Transient FEBasis
 struct TransientFEBasis{A} <: FEBasis

--- a/src/TransientFETools/TransientFEOperators.jl
+++ b/src/TransientFETools/TransientFEOperators.jl
@@ -233,7 +233,7 @@ function allocate_residual(op::TransientFEOperatorFromWeakForm,uh::FEFunction,ca
   V = get_test(op)
   v = get_fe_basis(V)
   dxh = ()
-  for i in 1:get_order(op)+1
+  for i in 1:get_order(op)
     dxh = (dxh...,uh)
   end
   xh = TransientCellField(uh,dxh)
@@ -256,7 +256,7 @@ end
 
 function allocate_jacobian(op::TransientFEOperatorFromWeakForm,uh::FEFunction,cache)
   dxh = ()
-  for i in 1:get_order(op)+1
+  for i in 1:get_order(op)
     dxh = (dxh...,uh)
   end
   xh = TransientCellField(uh,dxh)

--- a/src/TransientFETools/TransientFETools.jl
+++ b/src/TransientFETools/TransientFETools.jl
@@ -76,7 +76,10 @@ export test_transient_fe_solver
 
 export TransientFEFunction
 import Gridap.FESpaces: FEFunction
+import Gridap.FESpaces: SingleFieldFEFunction
 import Gridap.FESpaces: EvaluationFunction
+import Gridap.MultiField: MultiFieldFEFunction
+import Gridap.MultiField: num_fields
 
 export TransientFESolution
 import Gridap: solve
@@ -87,6 +90,7 @@ export test_transient_fe_solution
 
 export TransientCellField
 using Gridap.CellData: CellField
+using Gridap.CellData: GenericCellField
 using Gridap.MultiField: MultiFieldCellField
 using Gridap.FESpaces: FEBasis
 import Gridap.CellData: get_data
@@ -100,6 +104,8 @@ import Gridap.FESpaces: BasisStyle
 include("TransientFESpaces.jl")
 
 include("TransientCellField.jl")
+
+include("TransientMultiFieldCellField.jl")
 
 include("TransientFEOperators.jl")
 

--- a/src/TransientFETools/TransientFETools.jl
+++ b/src/TransientFETools/TransientFETools.jl
@@ -85,7 +85,7 @@ export TransientFESolution
 import Gridap: solve
 import GridapODEs.ODETools: ODESolution
 import GridapODEs.ODETools: GenericODESolution
-import Base: iterate
+import Base: iterate, view
 export test_transient_fe_solution
 
 export TransientCellField

--- a/src/TransientFETools/TransientFETools.jl
+++ b/src/TransientFETools/TransientFETools.jl
@@ -85,11 +85,12 @@ export TransientFESolution
 import Gridap: solve
 import GridapODEs.ODETools: ODESolution
 import GridapODEs.ODETools: GenericODESolution
-import Base: iterate, view
+import Base: iterate
 export test_transient_fe_solution
 
 export TransientCellField
 using Gridap.CellData: CellField
+using Gridap.CellData: CellFieldAt
 using Gridap.CellData: GenericCellField
 using Gridap.MultiField: MultiFieldCellField
 using Gridap.FESpaces: FEBasis

--- a/src/TransientFETools/TransientMultiFieldCellField.jl
+++ b/src/TransientFETools/TransientMultiFieldCellField.jl
@@ -1,0 +1,56 @@
+struct TransientMultiFieldCellField{A} <: TransientCellField
+  transient_single_fields::Vector{<:TransientCellField} # used to iterate
+  cellfield::A
+  derivatives::Tuple
+end
+
+MultiFieldTypes = Union{MultiFieldCellField,MultiFieldFEFunction}
+
+function TransientCellField(multi_field::MultiFieldTypes,derivatives::Tuple)
+  transient_single_fields = TransientCellField[]
+  for ifield in 1:num_fields(multi_field)
+    single_field = multi_field[ifield]
+    single_derivatives = ()
+    for ifield_derivatives in derivatives
+      single_derivatives = (single_derivatives...,getindex(ifield_derivatives,ifield))
+    end
+    transient_single_field = TransientSingleFieldCellField(single_field,single_derivatives)
+    push!(transient_single_fields,transient_single_field)
+  end
+  TransientMultiFieldCellField(transient_single_fields,multi_field,derivatives)
+end
+
+function get_data(f::TransientMultiFieldCellField)
+  s = """
+  Function get_data is not implemented for TransientMultiFieldCellField at this moment.
+  You need to extract the individual fields and then evaluate them separatelly.
+
+  If ever implement this, evaluating a `MultiFieldCellField` directly would provide,
+  at each evaluation point, a tuple with the value of the different fields.
+  """
+  @notimplemented s
+end
+
+function get_triangulation(f::TransientMultiFieldCellField)
+  s1 = first(f.single_fields)
+  trian = get_triangulation(s1)
+  @check all(map(i->trian===get_triangulation(i),f.single_fields))
+  trian
+end
+DomainStyle(::Type{TransientMultiFieldCellField{DS}}) where DS = DS()
+num_fields(a::TransientMultiFieldCellField) = length(a.transient_single_fields)
+Base.getindex(a::TransientMultiFieldCellField,i::Integer) = a.transient_single_fields[i]
+Base.iterate(a::TransientMultiFieldCellField)  = iterate(a.transient_single_fields)
+Base.iterate(a::TransientMultiFieldCellField,state)  = iterate(a.transient_single_fields,state)
+
+# Time derivative
+function ∂t(f::TransientMultiFieldCellField)
+  transient_single_field_derivatives = TransientCellField[]
+  for transient_single_field in f.transient_single_fields
+    push!(transient_single_field_derivatives,∂t(transient_single_field))
+  end
+  cellfield, derivatives = first_and_tail(f.derivatives)
+  TransientMultiFieldCellField(transient_single_field_derivatives,cellfield,derivatives)
+end
+
+∂tt(f::TransientMultiFieldCellField) = ∂t(∂t(f))

--- a/src/TransientFETools/TransientMultiFieldCellField.jl
+++ b/src/TransientFETools/TransientMultiFieldCellField.jl
@@ -54,3 +54,22 @@ function ∂t(f::TransientMultiFieldCellField)
 end
 
 ∂tt(f::TransientMultiFieldCellField) = ∂t(∂t(f))
+
+function Base.view(a::TransientMultiFieldCellField,indices::Vector{<:Int})
+  transient_single_fields = TransientCellField[]
+  cellfield = MultiFieldCellField(a.cellfield[indices],DomainStyle(a.cellfield))
+  derivatives = ()
+  for derivative in a.derivatives
+    derivatives = (derivatives...,MultiFieldCellField(derivative[indices],DomainStyle(derivative)))
+  end
+  for ifield in indices
+    single_field = a.cellfield[ifield]
+    single_derivatives = ()
+    for ifield_derivatives in a.derivatives
+      single_derivatives = (single_derivatives...,getindex(ifield_derivatives,ifield))
+    end
+    transient_single_field = TransientSingleFieldCellField(single_field,single_derivatives)
+    push!(transient_single_fields,transient_single_field)
+  end
+  TransientMultiFieldCellField(transient_single_fields,cellfield,derivatives)
+end

--- a/test/TransientFEsTests/FreeSurfacePotentialFlowTests.jl
+++ b/test/TransientFEsTests/FreeSurfacePotentialFlowTests.jl
@@ -69,6 +69,11 @@ jac_t(t,x,dxt,y) = m(dxt,y)
 op_trans = TransientFEOperator(res,jac,jac_t,X,Y)
 op_ad = TransientFEOperator(res,X,Y)
 
+# TransientFEOperator exploiting time derivative of separate fields (TransientMultiFieldCellField)
+res2(t,(ϕ,η),y) = m((∂t(ϕ),∂t(η)),y) + a((ϕ,η),y) - b(y)
+op_multifield = TransientFEOperator(res2,jac,jac_t,X,Y)
+
+
 # Solver
 ls = LUSolver()
 ode_solver = ThetaMethod(ls,Δt,θ)
@@ -100,6 +105,7 @@ end
 
 test_operator(op_const)
 test_operator(op_trans)
+test_operator(op_multifield)
 # test_operator(op_ad) # Not working yet
 
 end


### PR DESCRIPTION
Added `TransientMultiFieldCellField` to handle time derivatives on separate fields of a multi-field. Now these two versions are supported:
```julia
res(t,x,y) = m(∂t(x),y) + a(x,y) - b(y)
```
and
```julia
res2(t,(ϕ,η),y) = m((∂t(ϕ),∂t(η)),y) + a((ϕ,η),y) - b(y)
```
where `x=(ϕ,η)` is a multifield composed by singleFields `ϕ` and `η`. In principle this implementation should be able to handle recursivity (as a nice feature to have). 